### PR TITLE
Update usb_device.h

### DIFF
--- a/usb_cdc_g4/Inc/usb_device.h
+++ b/usb_cdc_g4/Inc/usb_device.h
@@ -35,7 +35,7 @@
 /* USER CODE BEGIN INCLUDE */
 void MX_USB_PCD_Init(void);
 
-PCD_HandleTypeDef hpcd_USB_FS;
+extern PCD_HandleTypeDef hpcd_USB_FS;
 /* USER CODE END INCLUDE */
 
 /** @addtogroup USBD_OTG_DRIVER


### PR DESCRIPTION
I always got this error, when I tried to compile:
`../stm32g4xx_usb_cdc-main/usb_cdc_g4/Inc/usb_device.h:38: multiple definition of `hpcd_USB_FS';`

According to 
https://community.st.com/s/question/0D53W00001Pv3zASAR/multiple-definition-error-after-stm32cubeide-190-update
and
https://gcc.gnu.org/gcc-10/porting_to.html

this seems to be an issue when you first developed with gcc9 and reused the variable hpcd_USB_FS in several files. I have not finally tested the function of the software, yet. But the compile error disappears, if you define hpcd_USB_FS as external.